### PR TITLE
Use apt-mirror, push weekly builds

### DIFF
--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,11 +1,11 @@
 name: Weekly
 
 on:
+  schedule:
+    - cron:  '0 0 * * 3'
   push:
     branches:
       - master
-  schedule:
-    - cron: '0 0 * * 3'
 
 jobs:
   build:
@@ -14,12 +14,17 @@ jobs:
       image: elementary/docker:stable
 
     steps:
-    - name: Clone build scripts
+    - name: Clone repository
       uses: actions/checkout@v1
 
-    - name: Build and upload distinst .iso
+    - name: Build metadata
       run: |
         ln -s $GITHUB_WORKSPACE /repo
         ./build.sh bionic stable
 
+    - name: Push metadata
+      run: |
+        ./commit.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,4 @@ To work around this and provide AppStream data for elementary packages available
 
 Building this metadata properly requires the `elementary-icon-theme` package to be installed so that the relevant icons can be extracted. So in a CI environment, an elementary Docker container is used. To build the metadata locally, you can use the following command:
 
-`docker run -i -v /tmp/ppa:/ppa_mirror -v ${PWD}:/repo elementary/docker:stable /bin/bash -s bionic stable < build.sh`
-
-The `/tmp/ppa` volume above ensures that the mirrored copy of the PPA isn't lost when the container is destroyed which is useful for speed and bandwidth if you're hacking on the build script, but isn't necessary for a one-time build.
+`docker run -i -v ${PWD}:/repo elementary/docker:stable /bin/bash -s bionic stable < build.sh`

--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,17 @@ DIST="$1"
 CHANNEL="$2"
 
 apt-get update
-apt-get install -y wget elementary-icon-theme appstream-generator
-mkdir -p /ppa_mirror
+apt-get install -y elementary-icon-theme appstream-generator apt-mirror
 
-# Recursively get anything that's not index.html* from the PPA
-wget -N -r -np -R "index.html*" -P/ppa_mirror http://ppa.launchpad.net/elementary-os/${CHANNEL}/ubuntu/
+# Configure apt-mirror and use it to mirror the needed series from the PPA
+cat <<EOF > /etc/apt/mirror.list
+set nthreads     20
+set _tilde 0
+
+deb http://ppa.launchpad.net/elementary-os/${CHANNEL}/ubuntu ${DIST} main
+EOF
+
+apt-mirror
 
 mkdir /workdir
 cd /workdir
@@ -18,7 +24,7 @@ cd /workdir
 cat <<EOF > asgen-config.json
 {
 "ProjectName": "elementary-${CHANNEL}",
-"ArchiveRoot": "/ppa_mirror/ppa.launchpad.net/elementary-os/${CHANNEL}/ubuntu",
+"ArchiveRoot": "/var/spool/apt-mirror/mirror/ppa.launchpad.net/elementary-os/${CHANNEL}/ubuntu",
 "Backend": "debian",
 "Suites":
   {

--- a/commit.sh
+++ b/commit.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+apt-get update
+apt-get install -y git
+
+# if a custom token is provided, use it instead of the default github token.
+if [ -n "$GIT_USER_TOKEN" ]; then
+  GITHUB_TOKEN="$GIT_USER_TOKEN"
+fi
+
+if [ -z "${GITHUB_TOKEN}" ]; then
+  echo "\033[0;31mERROR: The GITHUB_TOKEN environment variable is not defined.\033[0m"  && exit 1
+fi
+
+# default email and username to github actions user
+if [ -z "$GIT_USER_EMAIL" ]; then
+  GIT_USER_EMAIL="action@github.com"
+fi
+if [ -z "$GIT_USER_NAME" ]; then
+  GIT_USER_NAME="GitHub Action"
+fi
+
+cd /repo
+
+git fetch
+echo "Setting up git credentials..."
+git remote set-url origin https://x-access-token:"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git
+git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "$GIT_USER_NAME"
+echo "Git credentials configured."
+
+echo "Pushing new metadata to repository"
+git checkout master
+git add .
+git commit -m "Automatic update of metadata"
+git push --set-upstream origin master
+echo "Push complete"


### PR DESCRIPTION
Changes:
- Use `apt-mirror` for speed of mirroring PPA
- Add a script to push the updated metadata to the repo