### PR TITLE
Firefox AppData: Correct ID to match upstream

### DIFF
--- a/pantheon-data/extra/data/firefox.yml
+++ b/pantheon-data/extra/data/firefox.yml
@@ -1,5 +1,5 @@
 Type: desktop-application
-ID: org.mozilla.Firefox
+ID: org.mozilla.firefox
 Package: firefox
 Name:
   C: Firefox


### PR DESCRIPTION
Upstream uses a lower-case `f` https://flathub.org/apps/details/org.mozilla.firefox