### PR TITLE
Fix meson warning for run_command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,3 @@
 project('appstream-data-pantheon')
 
-run_script = run_command('bash', meson.project_name() + '.sh')
+run_script = run_command('bash', meson.project_name() + '.sh', check: false)


### PR DESCRIPTION
Since I am already fixing the other repos with this issue, I thought I might do it here aswell.

TLDR: meson will change the default behaviour of `run_command` and displays that as a warning when building.
See: https://github.com/mesonbuild/meson/issues/9300

![image](https://user-images.githubusercontent.com/10424668/193398817-a387b1cf-6b26-410f-8e6e-47dbfe25343d.png)
